### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - main
       - next
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Semantic Release


### PR DESCRIPTION
Potential fix for [https://github.com/MonsieurDahlstrom/tf-azure-cloudflared/security/code-scanning/7](https://github.com/MonsieurDahlstrom/tf-azure-cloudflared/security/code-scanning/7)

In general, the problem is fixed by explicitly declaring a `permissions` block in the workflow (either at the root or per job) so that the `GITHUB_TOKEN` is restricted to the minimum permissions needed. This avoids inheriting potentially broad organization/repository defaults and adheres to the principle of least privilege.

For this specific `release.yml`, the best fix without changing functionality is to add a workflow-level `permissions` block that grants `contents: write`. `semantic-release` typically needs to create tags and GitHub releases (which require contents write access). We don’t see any use of issues, PRs, or other APIs in the shown snippet, so we should not grant those. Adding the block at the top level (next to `on:` and `jobs:`) will apply to both the `release` job and the `manage_version` reusable workflow call, unless that reusable workflow overrides permissions internally. Concretely, in `.github/workflows/release.yml`, between the existing `on:` block (lines 3–8) and `jobs:` (line 9), insert:

```yaml
permissions:
  contents: write
```

No additional imports or external dependencies are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
