### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,8 @@
 name: Integration Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,6 +2,7 @@ name: Integration Tests
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/MonsieurDahlstrom/tf-azure-cloudflared/security/code-scanning/11](https://github.com/MonsieurDahlstrom/tf-azure-cloudflared/security/code-scanning/11)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal `GITHUB_TOKEN` scopes needed. Since this workflow only checks out code and interacts with external services (Azure, Cloudflare, Terraform) using secrets and OIDC, it does not need to write to the repository or to GitHub resources. The safest minimal setting is `permissions: contents: read` at the workflow level, which will apply to both `test-ubuntu` and `test-windows` jobs and remove reliance on inherited defaults.

Concretely, in `.github/workflows/integration-tests.yml`, add a top‑level `permissions` section after the `name` (or before/after `on:`—anywhere at the root level). Set `contents: read` so the checkout action can read the repository, but no write operations are allowed. No steps or actions in the current snippet require additional scopes like `pull-requests: write` or `id-token: write` (the Azure login action handles OIDC internally), so no further permissions are necessary. This change preserves existing functionality while tightening security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
