### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform-security-scan.yml
+++ b/.github/workflows/terraform-security-scan.yml
@@ -10,6 +10,9 @@ on:
       AZURE_TENANT_ID:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Terraform Validation and Security


### PR DESCRIPTION
Potential fix for [https://github.com/MonsieurDahlstrom/tf-azure-cloudflared/security/code-scanning/10](https://github.com/MonsieurDahlstrom/tf-azure-cloudflared/security/code-scanning/10)

In general, fix this by explicitly declaring `permissions:` in the workflow (either at the root or per-job) and restricting `GITHUB_TOKEN` to the minimal scopes required. Since this workflow only reads repository contents and uploads a SARIF file, `contents: read` is sufficient.

The best fix here is to add a `permissions:` block at the top (workflow) level so it applies to all jobs without changing each job individually. Insert it just after the `on:` block and before `jobs:` in `.github/workflows/terraform-security-scan.yml`. Set `contents: read` to align with CodeQL’s minimal recommendation. No extra imports or dependencies are needed; this is purely a YAML configuration change.

Concretely: in `.github/workflows/terraform-security-scan.yml`, after line 12 (the end of the `workflow_call`/`secrets` section), add:

```yaml
permissions:
  contents: read
```

This constrains the `GITHUB_TOKEN` for the workflow while preserving all existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
